### PR TITLE
Write Fixes

### DIFF
--- a/examples/ex_2.jl
+++ b/examples/ex_2.jl
@@ -19,7 +19,7 @@ f_ntile = get(fileatts,"ntile",1)
 filename = joinpath(savedir,"THETA.0009.nc")
 
 # Create the NetCDF file and populate with dimension and field info
-ds,fieldvars,dimlist = createfile(filename,ncvars,README,fillval = f_fillval,missval=f_missval,ff=f_ff,ntile=f_ntile)
+ds,fieldvars,dimlist = createfile(filename,ncvars,README,fillval = f_fillval,missval=f_missval,itile=f_ff,ntile=f_ntile)
 
 # Add field and dimension data and close the file
 addData(ds["THETA"],ncvars["THETA"])

--- a/examples/ex_3.jl
+++ b/examples/ex_3.jl
@@ -1,4 +1,4 @@
-using NCTiles,NCDatasets,NetCDF,Dates,Printf
+using NCTiles,NCDatasets,NetCDF,Dates,Printf,MITgcmTools
 
 examplesdir = joinpath("data","ex3")
 indir = joinpath(examplesdir,"data","cs510","diags_interp")

--- a/examples/ex_4.jl
+++ b/examples/ex_4.jl
@@ -1,4 +1,4 @@
-using MeshArrays, NCDatasets, NCTiles
+using MeshArrays, NCDatasets, NCTiles, MITgcmTools
 grid = GridSpec("LatLonCap","grids/GRID_LLC90/")
 
 exampledir = joinpath("data","ex4")
@@ -34,7 +34,7 @@ for f in land.fIndex
     end
 end
 
-tilarea = TileData(gridvars["RAC"],tilesize,grid)
+tilarea = TileData(gridvars["RAC"],tilesize,grid) # shouldn't need to pass in grid when passing in MeshArray object, can get it from MeshArray object
 tilland = TileData(land,tilesize,grid)
 thic = gridvars["DRC"]
 

--- a/src/NCTiles.jl
+++ b/src/NCTiles.jl
@@ -3,6 +3,8 @@ module NCTiles
 using NCDatasets,NetCDF,Dates,MeshArrays,Printf
 #using MITgcmTools
 
+import Base: getindex
+
 include("write.jl")
 include("read.jl")
 include("tile_support.jl")

--- a/src/NCTiles.jl
+++ b/src/NCTiles.jl
@@ -3,7 +3,6 @@ module NCTiles
 using NCDatasets,NetCDF,Dates,MeshArrays,Printf
 #using MITgcmTools
 
-import Base: getindex
 
 include("write.jl")
 include("read.jl")

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -16,7 +16,7 @@ function getnsteps(d)
         ds = Dataset(d.fname)
         tdim = dimnames(ds[d.varname])[end]
         timeUnits = ["minutes","seconds","hours","days","minute","second","hour","day"]
-        if any(occursin.(timeUnits,Ref(lowercase(ds[tdim].attrib["units"]))))
+        if any(occursin.(timeUnits,Ref(lowercase(ds[tdim].attrib["units"])))) || get(ds[tdim].attrib,"long_name","")=="Time coordinate"
             nsteps = length(ds[tdim])
         else
             nsteps = 1
@@ -39,7 +39,11 @@ Helper function: Checks that the size of the data about to be written to the fil
 matches the provided dimensions. Not exported.
 """
 function checkdims(v0::Array,var::NCvar)
-    dimlist = getfield.(var.dims[istimedim.(var.dims).==false],:name)
+    if isa(var.values[1],Number)
+        dimlist = getfield.(var.dims,:name)
+    else
+        dimlist = getfield.(var.dims[istimedim.(var.dims).==false],:name)
+    end
     if length(size(v0)) != length(dimlist)
         dimlist = join(dimlist,", ")
         error("Size of $(var.name) $(size(v0)) does not match its dimension list: ($dimlist)")
@@ -55,7 +59,7 @@ Helper function: determines whether d is a time dimension. Not exported.
 function istimedim(d::NCvar)
 
     timeUnits = ["minutes","seconds","hours","days","minute","second","hour","day"]
-    return any(occursin.(timeUnits,Ref(lowercase(d.units))))
+    return any(occursin.(timeUnits,Ref(lowercase(d.units)))) || get(d.atts,"long_name","")=="Time coordinate"
 
 end
 

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -3,7 +3,7 @@
     getnsteps(d)
 
 Helper function: Determines number of time steps in data d. Input d can be
-BinData, NCData, TileData, or an Array. Not exported.
+BinData, NCData, TileData, or an Array.
 """
 function getnsteps(d)
     if isa(d,BinData)
@@ -36,7 +36,7 @@ end
     checkdims(v0::Array,var::NCvar)
 
 Helper function: Checks that the size of the data about to be written to the file
-matches the provided dimensions. Not exported.
+matches the provided dimensions.
 """
 function checkdims(v0::Array,var::NCvar)
     if isa(var.values,Array) && isa(var.values[1],Number)
@@ -54,7 +54,7 @@ end
 """
     istimedim(d::Union{NCvar,NCDatasets.CFVariable})
 
-Helper function: determines whether d is a time dimension. Not exported.
+Helper function: determines whether d is a time dimension.
 """
 function istimedim(d::Union{NCvar,NCDatasets.CFVariable})
     if isa(d,NCvar)
@@ -72,7 +72,7 @@ end
     findtimedim(v::Array)
 
 Helper function: finds which dimension is a time dimension, if any. Can be Array of
-    NCvars or NCDatasets.CFVariables. Not exported.
+    NCvars or NCDatasets.CFVariables.
 """
 function findtimedim(dims::Array)
     return findall(istimedim.(dims))[1]
@@ -85,7 +85,7 @@ findtimedim(ds::NCDatasets.Dataset,v::NCDatasets.CFVariable) = findtimedim([ds[d
     hastimedim::Array)
 
 Helper function: determines whether an array of dimensions has a time dimension. Can 
-    be Array of NCvars or NCDatasets.CFVariables.Not exported.
+    be Array of NCvars or NCDatasets.CFVariables.
 """
 function hastimedim(dims::Array)
     return any(istimedim.(dims))
@@ -94,7 +94,7 @@ end
 """
     hastimedim(v::NCvar)
 
-Helper function: determines whether a variable has a time dimension. Not exported.
+Helper function: determines whether a variable has a time dimension.
 """
 function hastimedim(v::NCvar)
     ncvardim = isa.(v.dims,NCvar)

--- a/src/read.jl
+++ b/src/read.jl
@@ -131,12 +131,17 @@ function readncfile(fname,backend::Module=NCDatasets)
                 k_dims = Array{NCvar,1}()
                 for d in dimnames(ds[k])
                     #global k_dims,dims
-                    if !haskey(dims,d) # Add the dimension
-                        d_units = get(ds[d].attrib,"units","")
-                        d_dims = length(ds[d])
-                        d_values = NCData(fname,d,backend,typeof(ds[d][1])) # Pointer to this variable in the file
-                        d_atts = Dict(ds[d].attrib)
-                        dims[d] = NCvar(d,d_units,d_dims,d_values,d_atts,backend)
+                    if !haskey(dims,d) 
+                        if haskey(ds,d) # Add the dimension
+                            d_units = get(ds[d].attrib,"units","")
+                            d_dims = length(ds[d])
+                            d_values = NCData(fname,d,backend,typeof(ds[d][1])) # Pointer to this variable in the file
+                            d_atts = Dict(ds[d].attrib)
+                            dims[d] = NCvar(d,d_units,d_dims,d_values,d_atts,backend)
+                        else
+                            dims[d] = NCvar(d,"",ds.dim[d],[],Dict(),backend)
+                        end
+
                     end
                     k_dims = cat(k_dims,dims[d],dims=1)
                 end

--- a/src/read.jl
+++ b/src/read.jl
@@ -43,7 +43,7 @@ readbin(flddata::BinData,tidx=1) = readbin(flddata.fnames[tidx],flddata.precisio
     readncdata(var::NCData,i::Union{Colon,Integer}=:)
 
 Read netcdf file as specified in `NCData` argument. Optional
-argument `i` can be used to read a specific records / times. Not exported.
+argument `i` can be used to read a specific records / times.
 """
 function readncdata(var::NCData,i::Union{Colon,Integer}=:)
     ds = Dataset(var.fname)
@@ -67,7 +67,7 @@ end
 """
     readdata(flddata,tidx=1)
 
-Generic wrapper function to read data from a file regardless of file/data type. Not exported.
+Generic wrapper function to read data from a file regardless of file/data type.
 """
 function readdata(flddata,tidx=1)
     if isa(flddata,BinData)

--- a/src/write.jl
+++ b/src/write.jl
@@ -22,7 +22,7 @@ end
     replacevalues(vals,ncvar::NCvar)
 
 Helper function: Replaces the "values" attribute of an ncvar without changing
-anything else. Used to apply land mask. Not exported.
+anything else. Used to apply land mask.
 """
 replacevalues(vals,ncvar::NCvar) = NCvar(ncvar.name,ncvar.units,ncvar.dims,vals,ncvar.atts,ncvar.backend)
 
@@ -103,12 +103,11 @@ TileData(vals,tilesize::Tuple,grid::String="LatLonCap") = TileData(vals,tilesize
     replacevalues(vals,td::TileData)
 
 Helper function: Replaces the "values" attribute of a TilData struct without changing
-anything else. Used to apply land mask. Not exported.
+anything else. Used to apply land mask.
 """
 replacevalues(vals,td::TileData) = TileData(vals,td.tileinfo,td.tilesize,td.precision,td.numtiles)
 
-#Commented since "WARNING: import of Base.getindex into NCTiles conflicts with an existing identifier; ignored."
-#import Base: getindex
+import Base: getindex
 
 """
     getindex(v::NCvar,i::Integer)
@@ -219,8 +218,7 @@ function addVar(field::NCvar)
         attributes = field.atts
     end
     fieldvar = NcVar(field.name,dimlist,
-        atts = merge(Dict(("units" =>field.units)),field.atts))#,
-        #t = field.values.precision)
+        atts = merge(Dict(("units" =>field.units)),field.atts))
 end
 
 """
@@ -420,8 +418,8 @@ function createfile(filename, field::Union{NCvar,Dict}, README;
 
     if ~isempty(README)
         if isa(README,Array) && length(README) > 1
-            description = ["description" => README[1],
-            [string(Char(65+(i-2))) => README[i] for i in 2:length(README)]]
+            description = vcat("description" => README[1],
+            [string(Char(65+(i-2))) => README[i] for i in 2:length(README)])
         else
             description = ["description" => isa(README,Array) ? README[1] : README]
         end
@@ -430,7 +428,7 @@ function createfile(filename, field::Union{NCvar,Dict}, README;
     end
 
     file_atts = vcat(["date" => Dates.format(today(),"dd-u-yyyy"),
-    "Conventions" => "CF-1.6"])#haskey(attribs,"Conventions") ? pop!(attribs,"Conventions",nothing) : "CF-1.6"])
+    "Conventions" => "CF-1.6"])
 
     if ~isempty(description)
         file_atts = vcat(file_atts,description)

--- a/src/write.jl
+++ b/src/write.jl
@@ -393,7 +393,7 @@ function createfile(filename, field::Union{NCvar,Dict}, README;
     end
 
     if isa(fieldnames,Array)
-        fieldnamestring = join(fieldnames,",")
+        fieldnamestring = join(filter(x -> x !== "climatology_bounds", fieldnames),",")
     else
         fieldnamestring = fieldnames
     end
@@ -445,8 +445,6 @@ function createfile(filename, field::Union{NCvar,Dict}, README;
     if ~isnothing(attribs)
         file_atts = vcat(file_atts,[k => attribs[k] for k in keys(attribs)])
     end
-
-    println(file_atts)
 
     if backend == NCDatasets
         ds =  Dataset(filename,"c",attrib=file_atts)


### PR DESCRIPTION
Some general fixes to expand read/write functionality.

- Allows for more global (file) attributes
- Some fixes for reading in a climatology NetCDF file
- Clean up helper functions (mostly timedim functions)
- Adding import of getindex back in (required for overloading the getindex fnc for indexing)